### PR TITLE
make email files readable on non Mac platforms

### DIFF
--- a/mock-smtp.py
+++ b/mock-smtp.py
@@ -54,6 +54,7 @@ class MockSMTPServer(smtpd.SMTPServer):
             mail.write('%s\n' % line)
 
         mail.close()
+        os.chmod(file, 0o777)
 
         logging.info('%s => %s: %s', mailfrom, rcpttos, file)
 


### PR DESCRIPTION
Firstly, thank you for this repo, great for testing email!

I ran into an issue on Linux, whereby I was not able to read files that were written in a bind volume from the container.
This is because by default, 0600 privileges are given to the files, as in owner RW. However, on Linux, Docker is often run as root, but users are not.
This fixes it by changing the privileges on the file.

I assume this might have gone unnoticed, since it works fine on a Mac (I tried both platforms, works on Mac, works on Linux after this change).